### PR TITLE
Utilitytesting

### DIFF
--- a/src/Activity.js
+++ b/src/Activity.js
@@ -1,3 +1,5 @@
+import Utility from "./Utility";
+
 class Activity extends Utility {
   constructor(dataSet, userID) {
     super (dataSet, userID);

--- a/src/Activity.js
+++ b/src/Activity.js
@@ -1,21 +1,22 @@
 import Utility from "./Utility";
 
 class Activity extends Utility {
-  constructor(dataSet, userID) {
+  constructor(dataSet, userID, userData) {
     super (dataSet, userID);
+    this.userData = userData
   }
 
   returnMilesWalked() {
-    return Number((this.user.strideLength * this.singleUserData[this.singleUserData.length - 1].numSteps / 5280).toFixed(2))
+    return Number((this.userData.strideLength * this.singleUserData[this.singleUserData.length - 1].numSteps / 5280).toFixed(2))
   }
 
   metStepGoal(date) {
     let numSteps = this.singleUserData.find(day => day.date === date).numSteps
-    return numSteps >= this.user.dailyStepGoal
+    return numSteps >= this.userData.dailyStepGoal
   }
 
   returnAllStepGoalDays() {
-    let stepGoal = this.user.dailyStepGoal;
+    let stepGoal = this.userData.dailyStepGoal;
     return this.singleUserData.filter(day => day.numSteps >= stepGoal).map(day => day.date);
   }
 
@@ -24,17 +25,17 @@ class Activity extends Utility {
   }
 
   returnFriendsStepCount() {
-    let friends = this.user.friends.map(friend => this.activityData.filter(el => el.userID === friend));
+    let friends = this.userData.friends.map(friend => this.dataSet.filter(el => el.userID === friend));
     let friendDataForDates = friends.map(friend => [...friend].splice(-7));
     let totalStepsPerFriend = friendDataForDates.map(friend => friend.reduce((totalSteps, day) => {
       totalSteps += day.numSteps
       return totalSteps
     }, 0));
-    var stepObj = this.user.friends.reduce((friendSteps, friend, index) => {
+    var stepObj = this.userData.friends.reduce((friendSteps, friend, index) => {
       friendSteps[friend] = totalStepsPerFriend[index];
       return friendSteps
     }, {})
-    return [stepObj, this.user.friends[totalStepsPerFriend.indexOf(Math.max(...totalStepsPerFriend))]]
+    return [stepObj, this.userData.friends[totalStepsPerFriend.indexOf(Math.max(...totalStepsPerFriend))]]
   }
 
   returnThreeDayStepStreak() {
@@ -63,7 +64,6 @@ class Activity extends Utility {
     });
     return dates;
   }
-
 }
 
 export default Activity;

--- a/src/Hydration.js
+++ b/src/Hydration.js
@@ -1,3 +1,5 @@
+import Utility from "./Utility";
+
 class Hydration extends Utility {
   constructor(dataSet, userID) {
     super (dataSet, userID);

--- a/src/Sleep.js
+++ b/src/Sleep.js
@@ -1,3 +1,5 @@
+import Utility from "./Utility";
+
 class Sleep extends Utility {
   constructor(dataSet, userID) {
     super(dataSet, userID);

--- a/src/Sleep.js
+++ b/src/Sleep.js
@@ -6,7 +6,7 @@ class Sleep extends Utility {
   }
 
   returnWeekOfSleepInfo(week, metric) {
-    return this.returnWeekOfData(week, this.singleUserData).map(day =>
+    return this.returnWeekOfStatsForUser(week, this.singleUserData).map(day =>
       day[metric]);
   }
 }

--- a/src/Utility.js
+++ b/src/Utility.js
@@ -25,9 +25,9 @@ class Utility {
   }
 
   returnAvgUserStatForWeek(week, metric) {
-    let weekOfData = this.returnWeekDatesOnly(week, this.singleUserData);
+    let weekOfData = this.returnWeekOfStatsForUser(week, this.singleUserData);
     return Math.floor(weekOfData.reduce((totalMetric, eachDay) => {
-      totalMetric += eachDay[metric]
+      totalMetric += eachDay[metric]; 
       return totalMetric
     }, 0) / 7)
   }

--- a/src/Utility.js
+++ b/src/Utility.js
@@ -5,7 +5,7 @@ class Utility {
     this.singleUserData = this.dataSet.filter(stat => stat.userID === this.userID);
   }
 
-  returnWeekDatesOnly() {
+  returnWeekDatesOnly(week) {
     return [...this.singleUserData].splice(-7 * week, 7).map(day => day.date);
   }
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -1,7 +1,7 @@
 
 import $ from 'jquery';
 
-import Utlity from "./Utility";
+import Utility from "./Utility";
 import UserRepo from "./UserRepo";
 import User from "./User";
 import Hydration from "./Hydration";

--- a/test/Activity-test.js
+++ b/test/Activity-test.js
@@ -14,160 +14,32 @@ describe('Activity', () => {
 
   beforeEach(() => {
     user = new User(userData[0])
-    activity = new Activity(activityData, user)
+    activity = new Activity(activityData, user.id, user)
   });
 
   it('should be a function', () => {
     expect(Activity).to.be.a('function');
   });
 
-  it('should have access to userData', () => {
-    expect(activity.user).to.eql(userData[0]);
-  });
-
-  it('should have access to activityData', () => {
-    expect(activity.activityData).to.eql(activityData);
-  });
-
-  it('should be able to specify specific user', () => {
-    expect(activity.findUser()).to.eql([
-  { userID: 1,
-    date: '2019/06/15',
-    numSteps: 3577,
-    minutesActive: 140,
-    flightsOfStairs: 16 },
-  { userID: 1,
-    date: '2019/06/16',
-    numSteps: 6637,
-    minutesActive: 175,
-    flightsOfStairs: 36 },
-  { userID: 1,
-    date: '2019/06/17',
-    numSteps: 14329,
-    minutesActive: 168,
-    flightsOfStairs: 18 },
-  { userID: 1,
-    date: '2019/06/18',
-    numSteps: 4419,
-    minutesActive: 165,
-    flightsOfStairs: 33 },
-  { userID: 1,
-    date: '2019/06/19',
-    numSteps: 8429,
-    minutesActive: 275,
-    flightsOfStairs: 2 },
-  { userID: 1,
-    date: '2019/06/20',
-    numSteps: 6000,
-    minutesActive: 140,
-    flightsOfStairs: 36 },
-  { userID: 1,
-    date: '2019/06/21',
-    numSteps: 6760,
-    minutesActive: 135,
-    flightsOfStairs: 6 },
-  { userID: 1,
-    date: '2019/06/22',
-    numSteps: 10289,
-    minutesActive: 119,
-    flightsOfStairs: 6 },
-  { userID: 1,
-    date: '2019/06/23',
-    numSteps: 13928,
-    minutesActive: 218,
-    flightsOfStairs: 21 },
-  { userID: 1,
-    date: '2019/06/24',
-    numSteps: 7186,
-    minutesActive: 25,
-    flightsOfStairs: 15 },
-  { userID: 1,
-    date: '2019/06/25',
-    numSteps: 3093,
-    minutesActive: 185,
-    flightsOfStairs: 25 },
-  { userID: 1,
-    date: '2019/06/26',
-    numSteps: 8105,
-    minutesActive: 219,
-    flightsOfStairs: 28 } ]);
-  });
-
-  it('should return a weeks worth of user activity stats', () => {
-    expect(activity.returnWeekOfData(1, activity.findUser())).to.eql([
-  { userID: 1,
-    date: '2019/06/20',
-    numSteps: 6000,
-    minutesActive: 140,
-    flightsOfStairs: 36 },
-  { userID: 1,
-    date: '2019/06/21',
-    numSteps: 6760,
-    minutesActive: 135,
-    flightsOfStairs: 6 },
-  { userID: 1,
-    date: '2019/06/22',
-    numSteps: 10289,
-    minutesActive: 119,
-    flightsOfStairs: 6 },
-  { userID: 1,
-    date: '2019/06/23',
-    numSteps: 13928,
-    minutesActive: 218,
-    flightsOfStairs: 21 },
-  { userID: 1,
-    date: '2019/06/24',
-    numSteps: 7186,
-    minutesActive: 25,
-    flightsOfStairs: 15 },
-  { userID: 1,
-    date: '2019/06/25',
-    numSteps: 3093,
-    minutesActive: 185,
-    flightsOfStairs: 25 },
-  { userID: 1,
-    date: '2019/06/26',
-    numSteps: 8105,
-    minutesActive: 219,
-    flightsOfStairs: 28 } ]);
-  });
-
-  it('should return the number of steps for specific user for a specific day', () => {
-    expect(activity.returnNumStepsDay("2019/06/17")).to.equal(14329);
+  it('should be an instance of the class Activity', () => {
+    expect(activity).to.be.an.instanceOf(Activity);
   });
 
   it('should return the miles walked by a specific user for a specific day', () => {
     expect(activity.returnMilesWalked()).to.equal(6.60);
   });
 
-  it('should return number of flights of stairs climbed by a specific user for a specific day', () => {
-    expect(activity.returnDaysActivityInfo("2019/06/17", 'flightsOfStairs')).to.equal(18);
-  });
+  describe('metStepGoal', () => {
 
-  it('should return the minutes active for a day', () => {
-    expect(activity.returnDaysActivityInfo("2019/06/26", 'minutesActive')).to.equal(219);
-  });
+    it('should return false if they did not meet their step goal for a date', () => {
+      expect(activity.metStepGoal('2019/06/15')).to.equal(false);
+    });
 
-  it('should return the average minutes active for a week', () => {
-    expect(activity.returnAverageActivityForWeek(1, 'minutesActive')).to.equal(148);
-  });
+    it('should return true if they did  meet their step goal for a date', () => {
+      expect(activity.metStepGoal("2019/06/17")).to.equal(true);
+    });
 
-  it('should return the average steps for a week', () => {
-    expect(activity.returnAverageActivityForWeek(1, 'numSteps')).to.equal(7908);
-  });
-
-  it('should return the average steps for a week', () => {
-    expect(activity.returnAverageActivityForWeek(1, 'flightsOfStairs')).to.equal(19);
-  });
-
-  it('should return false if they did not meet their step goal for a date', () => {
-    expect(activity.metStepGoal('2019/06/15')).to.equal(false);
-  });
-
-
-  it('should return true if they did  meet their step goal for a date', () => {
-    expect(activity.metStepGoal("2019/06/17")).to.equal(true);
-  });
+  })
 
   it('should return all days where exceeded step goal ', () => {
     expect(activity.returnAllStepGoalDays()).to.eql(['2019/06/17', '2019/06/22', '2019/06/23']);

--- a/test/Hydration-test.js
+++ b/test/Hydration-test.js
@@ -25,39 +25,11 @@ describe('Hydration', () => {
     expect(hydration).to.be.an.instanceOf(Hydration);
   });
 
-  it('should hold hydration data', () => {
-    expect(hydration.hydrationData).to.eql(hydrationData);
-  });
-
-  it('should contain userID', () => {
-    expect(hydration.userID).to.equal(user.id);
-  });
-
-  it('should return the dates for the last week', () => {
-    expect(hydration.returnWeek()).to.eql(
-      [
-        "2019/06/16",
-        "2019/06/17",
-        "2019/06/18",
-        "2019/06/19",
-        "2019/06/20",
-        "2019/06/21",
-        "2019/06/22"
-      ])
-  });
-
   it('should return the average fluid ounces for a user for all time', () => {
     expect(hydration.returnAverageFluidOunces()).to.equal(62);
-  });
-
-  it('should return the amount of fluid ounces consumed on a specific date for a specific person', () => {
-    expect(hydration.returnDailyFluidOunces('2019/06/15')).to.equal(37);
   });
 
   it('should return the amount of ounces consumed for one person over a week', () => {
     expect(hydration.returnWeeklyNumOunces(1)).to.eql([69, 96, 61, 91, 50, 50, 43]);
   });
-
-
-
 })

--- a/test/Sleep-test.js
+++ b/test/Sleep-test.js
@@ -15,7 +15,6 @@ describe('Sleep', () => {
   beforeEach(() => {
     user = new User(userData[0]);
     sleep = new Sleep(sleepData, user.id);
-    fullSleep = new Sleep(allSleepData, user.id);
   })
 
   it('should be a function', () => {
@@ -26,48 +25,7 @@ describe('Sleep', () => {
     expect(sleep).to.be.an.instanceOf(Sleep);
   });
 
-  it('should be able to store sleep data as a parameter', () => {
-    expect(sleep.sleepData).to.eql(sleepData);
+  it('should be able return a week\'s worth of sleep data for a user', () => {
+    expect(sleep.returnWeekOfSleepInfo(1, 'sleepQuality')).to.eql([1.2, 1.2, 4.2, 3, 1.5, 1.3, 3.7]);
   });
-
-  it('should be able to store user id as a parameter', () => {
-    expect(sleep.userID).to.equal(user.id);
-  });
-
-  it('should return an array of dates for any desired week', () => {
-    expect(sleep.returnWeek(1)).to.eql([
-      "2019/06/19",
-      "2019/06/20",
-      "2019/06/21",
-      "2019/06/22",
-      "2019/06/23",
-      "2019/06/24",
-      "2019/06/25",
-    ]);
-  });
-
-  it('should return the average sleep hours for a single user over all time', () => {
-    expect(sleep.returnAvgSleepInfo('hoursSlept')).to.equal(7.66);
-  });
-
-  it('should return the average sleep quality over all time for a single user', () => {
-    expect(sleep.returnAvgSleepInfo('sleepQuality')).to.equal(2.53);
-  });
-
-  it('should return how many hours slept for a specific day', () => {
-    expect(sleep.returnDaysSleepInfo('2019/06/15', 'hoursSlept')).to.equal(6.1);
-  });
-
-  it('should return sleep quality for a specific day', () => {
-    expect(sleep.returnDaysSleepInfo('2019/06/15', 'sleepQuality')).to.equal(2.2);
-  });
-
-  it('should return hours slept each day for week for a specific user', () => {
-    expect(fullSleep.returnWeekOfSleepInfo(2, 'hoursSlept')).to.eql([7.3, 5.1, 8.6, 10.5, 9.1, 6.5, 6.8]);
-  });
-
-  it('should return quality of sleep for the week for a specific user', () => {
-    expect(fullSleep.returnWeekOfSleepInfo(2, 'sleepQuality')).to.eql([4.8, 4.7, 3.7, 1.8, 1.5, 4.2, 2]);
-  });
-
 });

--- a/test/Utility-test.js
+++ b/test/Utility-test.js
@@ -12,12 +12,10 @@ import User from '../src/User';
 describe('Utility', () => {
   let user;
   let utility;
-  let fullSizeUtility;
 
   beforeEach(() => {
     user = new User(userData[0]);
     utility = new Utility(sleepData, user.id);
-    fullSizeUtility = new Utility(allSleepData, user.id);
   })
 
   it('should be a function', () => {

--- a/test/Utility-test.js
+++ b/test/Utility-test.js
@@ -99,24 +99,24 @@ describe('Utility', () => {
       ]);
     });
 
-    it.skip('should return the average sleep quality over all time for a single user', () => {
-      expect(utility.returnAvgSleepInfo('sleepQuality')).to.equal(2.53);
-    });
-
-    it.skip('should return how many hours slept for a specific day', () => {
-      expect(utility.returnDaysSleepInfo('2019/06/15', 'hoursSlept')).to.equal(6.1);
-    });
-
-    it.skip('should return sleep quality for a specific day', () => {
-      expect(utility.returnDaysSleepInfo('2019/06/15', 'sleepQuality')).to.equal(2.2);
-    });
-
-    it.skip('should return hours slept each day for week for a specific user', () => {
-      expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'hoursSlept')).to.eql([7.3, 5.1, 8.6, 10.5, 9.1, 6.5, 6.8]);
-    });
-
-    it.skip('should return quality of sleep for the week for a specific user', () => {
-      expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'sleepQuality')).to.eql([4.8, 4.7, 3.7, 1.8, 1.5, 4.2, 2]);
-    });
+    // it.skip('should return the average sleep quality over all time for a single user', () => {
+    //   expect(utility.returnAvgSleepInfo('sleepQuality')).to.equal(2.53);
+    // });
+    //
+    // it.skip('should return how many hours slept for a specific day', () => {
+    //   expect(utility.returnDaysSleepInfo('2019/06/15', 'hoursSlept')).to.equal(6.1);
+    // });
+    //
+    // it.skip('should return sleep quality for a specific day', () => {
+    //   expect(utility.returnDaysSleepInfo('2019/06/15', 'sleepQuality')).to.equal(2.2);
+    // });
+    //
+    // it.skip('should return hours slept each day for week for a specific user', () => {
+    //   expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'hoursSlept')).to.eql([7.3, 5.1, 8.6, 10.5, 9.1, 6.5, 6.8]);
+    // });
+    //
+    // it.skip('should return quality of sleep for the week for a specific user', () => {
+    //   expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'sleepQuality')).to.eql([4.8, 4.7, 3.7, 1.8, 1.5, 4.2, 2]);
+    // });
 
 });

--- a/test/Utility-test.js
+++ b/test/Utility-test.js
@@ -20,7 +20,7 @@ describe('Utility', () => {
     fullSizeUtility = new Utility(allSleepData, user.id);
   })
 
-  it.only('should be a function', () => {
+  it('should be a function', () => {
     expect(Utility).to.be.a('function');
   });
 
@@ -28,97 +28,89 @@ describe('Utility', () => {
     expect(utility).to.be.an.instanceOf(Utility);
   });
 
-    it('should be able to store sleep data in a property', () => {
-      expect(utility.dataSet).to.eql(sleepData);
-    });
+  it('should be able to store sleep data in a property', () => {
+    expect(utility.dataSet).to.eql(sleepData);
+  });
 
-    it('should be able to store userID in a property', () => {
-      expect(utility.userID).to.equal(user.id);
-    });
+  it('should be able to store userID in a property', () => {
+    expect(utility.userID).to.equal(user.id);
+  });
 
-    it('should be able to store a single user\'s data in a property', () => {
-      expect(utility.singleUserData.length).to.equal(11);
-    });
+  it('should be able to store a single user\'s data in a property', () => {
+    expect(utility.singleUserData.length).to.equal(11);
+  });
 
-    it('should return an array of dates for the final week', () => {
-      expect(utility.returnWeekDatesOnly(1)).to.eql([
-        "2019/06/19",
-        "2019/06/20",
-        "2019/06/21",
-        "2019/06/22",
-        "2019/06/23",
-        "2019/06/24",
-        "2019/06/25",
-      ]);
-    });
+  it('should return an array of dates for the final week', () => {
+    expect(utility.returnWeekDatesOnly(1)).to.eql([
+      "2019/06/19",
+      "2019/06/20",
+      "2019/06/21",
+      "2019/06/22",
+      "2019/06/23",
+      "2019/06/24",
+      "2019/06/25",
+    ]);
+  });
 
-    it('should return a user\'s sleep data for the final week', () => {
-      expect(utility.returnWeekOfStatsForUser(1, utility.singleUserData)).to.eql([
-        {
-          "userID": 1,
-          "date": "2019/06/19",
-          "hoursSlept": 10.7,
-          "sleepQuality": 1.2
-        },
-        {
-          "userID": 1,
-          "date": "2019/06/20",
-          "hoursSlept": 9.3,
-          "sleepQuality": 1.2
-        },
-        {
-          "userID": 1,
-          "date": "2019/06/21",
-          "hoursSlept": 7.8,
-          "sleepQuality": 4.2
-        },
-        {
-          "userID": 1,
-          "date": "2019/06/22",
-          "hoursSlept": 7,
-          "sleepQuality": 3
-        },
-        {
-          "userID": 1,
-          "date": "2019/06/23",
-          "hoursSlept": 7.8,
-          "sleepQuality": 1.5
-        },
-        {
-          "userID": 1,
-          "date": "2019/06/24",
-          "hoursSlept": 8,
-          "sleepQuality": 1.3
-        },
-        {
-          "userID": 1,
-          "date": "2019/06/25",
-          "hoursSlept": 5.1,
-          "sleepQuality": 3.7
-        }
-      ]);
-    });
+  it('should return a user\'s sleep data for the final week', () => {
+    expect(utility.returnWeekOfStatsForUser(1, utility.singleUserData)).to.eql([
+      {
+        "userID": 1,
+        "date": "2019/06/19",
+        "hoursSlept": 10.7,
+        "sleepQuality": 1.2
+      },
+      {
+        "userID": 1,
+        "date": "2019/06/20",
+        "hoursSlept": 9.3,
+        "sleepQuality": 1.2
+      },
+      {
+        "userID": 1,
+        "date": "2019/06/21",
+        "hoursSlept": 7.8,
+        "sleepQuality": 4.2
+      },
+      {
+        "userID": 1,
+        "date": "2019/06/22",
+        "hoursSlept": 7,
+        "sleepQuality": 3
+      },
+      {
+        "userID": 1,
+        "date": "2019/06/23",
+        "hoursSlept": 7.8,
+        "sleepQuality": 1.5
+      },
+      {
+        "userID": 1,
+        "date": "2019/06/24",
+        "hoursSlept": 8,
+        "sleepQuality": 1.3
+      },
+      {
+        "userID": 1,
+        "date": "2019/06/25",
+        "hoursSlept": 5.1,
+        "sleepQuality": 3.7
+      }
+    ]);
+  });
 
-    it('should return a specific stat for a user on a particular date', () => {
-      expect(utility.returnIndividualStatForDate('2019/06/15', 'hoursSlept')).to.equal(6.1);
-      expect(utility.returnIndividualStatForDate('2019/06/24', 'sleepQuality')).to.equal(1.3);
-    });
+  it('should return a specific stat for a user on a particular date', () => {
+    expect(utility.returnIndividualStatForDate('2019/06/15', 'hoursSlept')).to.equal(6.1);
+    expect(utility.returnIndividualStatForDate('2019/06/24', 'sleepQuality')).to.equal(1.3);
+  });
 
-    it('should return a user\'s all time average for a particular stat', () => {
-      expect(utility.returnAvgUserStatAllTime('hoursSlept')).to.equal(7.66);
-      expect(utility.returnAvgUserStatAllTime('sleepQuality')).to.equal(2.53);
-    });
+  it('should return a user\'s all time average for a particular stat', () => {
+    expect(utility.returnAvgUserStatAllTime('hoursSlept')).to.equal(7.66);
+    expect(utility.returnAvgUserStatAllTime('sleepQuality')).to.equal(2.53);
+  });
 
-    it.skip('should return sleep quality for a specific day', () => {
-      expect(utility.returnDaysSleepInfo('2019/06/15', 'sleepQuality')).to.equal(2.2);
-    });
-
-    it.skip('should return hours slept each day for week for a specific user', () => {
-      expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'hoursSlept')).to.eql([7.3, 5.1, 8.6, 10.5, 9.1, 6.5, 6.8]);
-    });
-
-    it.skip('should return quality of sleep for the week for a specific user', () => {
-      expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'sleepQuality')).to.eql([4.8, 4.7, 3.7, 1.8, 1.5, 4.2, 2]);
-    });
-
+  it('should return an average for a specific user stat over the final week', () => {
+    expect(utility.returnAvgUserStatForWeek(1, 'sleepQuality')).to.equal(2);
+    expect(utility.returnAvgUserStatForWeek(1, 'hoursSlept')).to.equal(7);
+  });
 });

--- a/test/Utility-test.js
+++ b/test/Utility-test.js
@@ -99,24 +99,25 @@ describe('Utility', () => {
       ]);
     });
 
-    // it.skip('should return the average sleep quality over all time for a single user', () => {
-    //   expect(utility.returnAvgSleepInfo('sleepQuality')).to.equal(2.53);
-    // });
-    //
-    // it.skip('should return how many hours slept for a specific day', () => {
-    //   expect(utility.returnDaysSleepInfo('2019/06/15', 'hoursSlept')).to.equal(6.1);
-    // });
-    //
-    // it.skip('should return sleep quality for a specific day', () => {
-    //   expect(utility.returnDaysSleepInfo('2019/06/15', 'sleepQuality')).to.equal(2.2);
-    // });
-    //
-    // it.skip('should return hours slept each day for week for a specific user', () => {
-    //   expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'hoursSlept')).to.eql([7.3, 5.1, 8.6, 10.5, 9.1, 6.5, 6.8]);
-    // });
-    //
-    // it.skip('should return quality of sleep for the week for a specific user', () => {
-    //   expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'sleepQuality')).to.eql([4.8, 4.7, 3.7, 1.8, 1.5, 4.2, 2]);
-    // });
+    it('should return a specific metric for a user on a specific date', () => {
+      expect(utility.returnIndividualStatForDate('2019/06/15', 'hoursSlept')).to.equal(6.1);
+      expect(utility.returnIndividualStatForDate('2019/06/24', 'sleepQuality')).to.equal(1.3);
+    });
+
+    it.skip('should return how many hours slept for a specific day', () => {
+      expect(utility.returnDaysSleepInfo('2019/06/15', 'hoursSlept')).to.equal(6.1);
+    });
+
+    it.skip('should return sleep quality for a specific day', () => {
+      expect(utility.returnDaysSleepInfo('2019/06/15', 'sleepQuality')).to.equal(2.2);
+    });
+
+    it.skip('should return hours slept each day for week for a specific user', () => {
+      expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'hoursSlept')).to.eql([7.3, 5.1, 8.6, 10.5, 9.1, 6.5, 6.8]);
+    });
+
+    it.skip('should return quality of sleep for the week for a specific user', () => {
+      expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'sleepQuality')).to.eql([4.8, 4.7, 3.7, 1.8, 1.5, 4.2, 2]);
+    });
 
 });

--- a/test/Utility-test.js
+++ b/test/Utility-test.js
@@ -28,91 +28,95 @@ describe('Utility', () => {
     expect(utility).to.be.an.instanceOf(Utility);
   });
 
-  it('should be able to store sleep data as a property', () => {
-    expect(utility.dataSet).to.eql(sleepData);
-  });
+    it('should be able to store sleep data in a property', () => {
+      expect(utility.dataSet).to.eql(sleepData);
+    });
 
-  it('should be able to store userID as a property', () => {
-    expect(utility.userID).to.equal(user.id);
-  });
+    it('should be able to store userID in a property', () => {
+      expect(utility.userID).to.equal(user.id);
+    });
 
-  it('should return an array of dates for the final week', () => {
-    expect(utility.returnWeekDatesOnly(1)).to.eql([
-      "2019/06/19",
-      "2019/06/20",
-      "2019/06/21",
-      "2019/06/22",
-      "2019/06/23",
-      "2019/06/24",
-      "2019/06/25",
-    ]);
-  });
+    it('should be able to store a single user\'s data in a property', () => {
+      expect(utility.singleUserData.length).to.equal(11);
+    });
 
-  it('should return a user\'s sleep data for the final week', () => {
-    expect(utility.returnWeekOfStatsForUser(1, utility.singleUserData)).to.eql([
-      {
-        "userID": 1,
-        "date": "2019/06/19",
-        "hoursSlept": 10.7,
-        "sleepQuality": 1.2
-      },
-      {
-        "userID": 1,
-        "date": "2019/06/20",
-        "hoursSlept": 9.3,
-        "sleepQuality": 1.2
-      },
-      {
-        "userID": 1,
-        "date": "2019/06/21",
-        "hoursSlept": 7.8,
-        "sleepQuality": 4.2
-      },
-      {
-        "userID": 1,
-        "date": "2019/06/22",
-        "hoursSlept": 7,
-        "sleepQuality": 3
-      },
-      {
-        "userID": 1,
-        "date": "2019/06/23",
-        "hoursSlept": 7.8,
-        "sleepQuality": 1.5
-      },
-      {
-        "userID": 1,
-        "date": "2019/06/24",
-        "hoursSlept": 8,
-        "sleepQuality": 1.3
-      },
-      {
-        "userID": 1,
-        "date": "2019/06/25",
-        "hoursSlept": 5.1,
-        "sleepQuality": 3.7
-      }
-    ]);
-  });
+    it('should return an array of dates for the final week', () => {
+      expect(utility.returnWeekDatesOnly(1)).to.eql([
+        "2019/06/19",
+        "2019/06/20",
+        "2019/06/21",
+        "2019/06/22",
+        "2019/06/23",
+        "2019/06/24",
+        "2019/06/25",
+      ]);
+    });
 
-  it.skip('should return the average sleep quality over all time for a single user', () => {
-    expect(utility.returnAvgSleepInfo('sleepQuality')).to.equal(2.53);
-  });
+    it('should return a user\'s sleep data for the final week', () => {
+      expect(utility.returnWeekOfStatsForUser(1, utility.singleUserData)).to.eql([
+        {
+          "userID": 1,
+          "date": "2019/06/19",
+          "hoursSlept": 10.7,
+          "sleepQuality": 1.2
+        },
+        {
+          "userID": 1,
+          "date": "2019/06/20",
+          "hoursSlept": 9.3,
+          "sleepQuality": 1.2
+        },
+        {
+          "userID": 1,
+          "date": "2019/06/21",
+          "hoursSlept": 7.8,
+          "sleepQuality": 4.2
+        },
+        {
+          "userID": 1,
+          "date": "2019/06/22",
+          "hoursSlept": 7,
+          "sleepQuality": 3
+        },
+        {
+          "userID": 1,
+          "date": "2019/06/23",
+          "hoursSlept": 7.8,
+          "sleepQuality": 1.5
+        },
+        {
+          "userID": 1,
+          "date": "2019/06/24",
+          "hoursSlept": 8,
+          "sleepQuality": 1.3
+        },
+        {
+          "userID": 1,
+          "date": "2019/06/25",
+          "hoursSlept": 5.1,
+          "sleepQuality": 3.7
+        }
+      ]);
+    });
 
-  it.skip('should return how many hours slept for a specific day', () => {
-    expect(utility.returnDaysSleepInfo('2019/06/15', 'hoursSlept')).to.equal(6.1);
-  });
+    it.skip('should return the average sleep quality over all time for a single user', () => {
+      expect(utility.returnAvgSleepInfo('sleepQuality')).to.equal(2.53);
+    });
 
-  it.skip('should return sleep quality for a specific day', () => {
-    expect(utility.returnDaysSleepInfo('2019/06/15', 'sleepQuality')).to.equal(2.2);
-  });
+    it.skip('should return how many hours slept for a specific day', () => {
+      expect(utility.returnDaysSleepInfo('2019/06/15', 'hoursSlept')).to.equal(6.1);
+    });
 
-  it.skip('should return hours slept each day for week for a specific user', () => {
-    expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'hoursSlept')).to.eql([7.3, 5.1, 8.6, 10.5, 9.1, 6.5, 6.8]);
-  });
+    it.skip('should return sleep quality for a specific day', () => {
+      expect(utility.returnDaysSleepInfo('2019/06/15', 'sleepQuality')).to.equal(2.2);
+    });
 
-  it.skip('should return quality of sleep for the week for a specific user', () => {
-    expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'sleepQuality')).to.eql([4.8, 4.7, 3.7, 1.8, 1.5, 4.2, 2]);
-  });
+    it.skip('should return hours slept each day for week for a specific user', () => {
+      expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'hoursSlept')).to.eql([7.3, 5.1, 8.6, 10.5, 9.1, 6.5, 6.8]);
+    });
+
+    it.skip('should return quality of sleep for the week for a specific user', () => {
+      expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'sleepQuality')).to.eql([4.8, 4.7, 3.7, 1.8, 1.5, 4.2, 2]);
+    });
 
 });

--- a/test/Utility-test.js
+++ b/test/Utility-test.js
@@ -20,7 +20,7 @@ describe('Utility', () => {
     fullSizeUtility = new Utility(allSleepData, user.id);
   })
 
-  it('should be a function', () => {
+  it.only('should be a function', () => {
     expect(Utility).to.be.a('function');
   });
 
@@ -99,13 +99,14 @@ describe('Utility', () => {
       ]);
     });
 
-    it('should return a specific metric for a user on a specific date', () => {
+    it('should return a specific stat for a user on a particular date', () => {
       expect(utility.returnIndividualStatForDate('2019/06/15', 'hoursSlept')).to.equal(6.1);
       expect(utility.returnIndividualStatForDate('2019/06/24', 'sleepQuality')).to.equal(1.3);
     });
 
-    it.skip('should return how many hours slept for a specific day', () => {
-      expect(utility.returnDaysSleepInfo('2019/06/15', 'hoursSlept')).to.equal(6.1);
+    it('should return a user\'s all time average for a particular stat', () => {
+      expect(utility.returnAvgUserStatAllTime('hoursSlept')).to.equal(7.66);
+      expect(utility.returnAvgUserStatAllTime('sleepQuality')).to.equal(2.53);
     });
 
     it.skip('should return sleep quality for a specific day', () => {

--- a/test/Utility-test.js
+++ b/test/Utility-test.js
@@ -1,0 +1,118 @@
+const chai = require('chai');
+const expect = chai.expect;
+
+import allSleepData from '../data/sleep';
+import sleepData from '../data/sleep-test-data';
+import userData from '../data/users-test-data';
+
+import Utility from '../src/Utility';
+import User from '../src/User';
+
+
+describe('Utility', () => {
+  let user;
+  let utility;
+  let fullSizeUtility;
+
+  beforeEach(() => {
+    user = new User(userData[0]);
+    utility = new Utility(sleepData, user.id);
+    fullSizeUtility = new Utility(allSleepData, user.id);
+  })
+
+  it('should be a function', () => {
+    expect(Utility).to.be.a('function');
+  });
+
+  it('should be an instance of the class Sleep', () => {
+    expect(utility).to.be.an.instanceOf(Utility);
+  });
+
+  it('should be able to store sleep data as a property', () => {
+    expect(utility.dataSet).to.eql(sleepData);
+  });
+
+  it('should be able to store userID as a property', () => {
+    expect(utility.userID).to.equal(user.id);
+  });
+
+  it('should return an array of dates for the final week', () => {
+    expect(utility.returnWeekDatesOnly(1)).to.eql([
+      "2019/06/19",
+      "2019/06/20",
+      "2019/06/21",
+      "2019/06/22",
+      "2019/06/23",
+      "2019/06/24",
+      "2019/06/25",
+    ]);
+  });
+
+  it('should return a user\'s sleep data for the final week', () => {
+    expect(utility.returnWeekOfStatsForUser(1, utility.singleUserData)).to.eql([
+      {
+        "userID": 1,
+        "date": "2019/06/19",
+        "hoursSlept": 10.7,
+        "sleepQuality": 1.2
+      },
+      {
+        "userID": 1,
+        "date": "2019/06/20",
+        "hoursSlept": 9.3,
+        "sleepQuality": 1.2
+      },
+      {
+        "userID": 1,
+        "date": "2019/06/21",
+        "hoursSlept": 7.8,
+        "sleepQuality": 4.2
+      },
+      {
+        "userID": 1,
+        "date": "2019/06/22",
+        "hoursSlept": 7,
+        "sleepQuality": 3
+      },
+      {
+        "userID": 1,
+        "date": "2019/06/23",
+        "hoursSlept": 7.8,
+        "sleepQuality": 1.5
+      },
+      {
+        "userID": 1,
+        "date": "2019/06/24",
+        "hoursSlept": 8,
+        "sleepQuality": 1.3
+      },
+      {
+        "userID": 1,
+        "date": "2019/06/25",
+        "hoursSlept": 5.1,
+        "sleepQuality": 3.7
+      }
+    ]);
+  });
+
+  it.skip('should return the average sleep quality over all time for a single user', () => {
+    expect(utility.returnAvgSleepInfo('sleepQuality')).to.equal(2.53);
+  });
+
+  it.skip('should return how many hours slept for a specific day', () => {
+    expect(utility.returnDaysSleepInfo('2019/06/15', 'hoursSlept')).to.equal(6.1);
+  });
+
+  it.skip('should return sleep quality for a specific day', () => {
+    expect(utility.returnDaysSleepInfo('2019/06/15', 'sleepQuality')).to.equal(2.2);
+  });
+
+  it.skip('should return hours slept each day for week for a specific user', () => {
+    expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'hoursSlept')).to.eql([7.3, 5.1, 8.6, 10.5, 9.1, 6.5, 6.8]);
+  });
+
+  it.skip('should return quality of sleep for the week for a specific user', () => {
+    expect(fullSizeUtility.returnWeekOfSleepInfo(2, 'sleepQuality')).to.eql([4.8, 4.7, 3.7, 1.8, 1.5, 4.2, 2]);
+  });
+
+});


### PR DESCRIPTION
**What's this PR do?**
### 1) Tasks related to building out the Utility test suite
- Corrects the typo for "Utility" in the scripts files (where Utility was imported)
- Adds a line of code to import Utility into each of its descendant classes (sleep, hydration, activity)
- Adds the testing suite for the Utility class
- Adds a parameter (week) to returnWeekDatesOnly() function in the Utility class
- Corrects the returnAvgUserStatForWeek() function in the Utility class (it had used the nested returnWeekDatesOnly() method inappropriately - this was replaced with the more appropriate returnWeekOfStatsForUser() method.

### 2) Tasks related to the reformatting of the tests for Sleep, Hydration, & Activity 
- I removed the tests that corresponded to old methods that were absorbed and refactored in the Utility class (sleep, hydration, and activity)
- In Sleep & Hydration, when we're instantiating within the test files, we've been passing two arguments: theDataSet(activityData or hydroData, etc) & the user.id (1 or 27, etc - an integer value)

It looks like this:
```
  beforeEach(() => {
    user = new User(userData[0])
    sleep = new Sleep(sleepData, user.id)
  });
```
In Activity, all of the functions were built to receive a slightly different second argument (user NOT user.id):
```
  beforeEach(() => {
    user = new User(userData[0])
    activity = new Activity(activityData, user)
  });
```
This created some problems. Most troublesome among them was that our this.singleUserData property inherited from the Utility class was returning undefined (and causing a cascade of undefined results in the functions relying on it) because it was built to receive a this.userID property initialized with just the user.id rather than user.
I had to reformat a few things to get things running smoothly.

1) I added a third property to the Activity class, userData.
2) I went into each function to include the property wherever appropriate (replacing this.user)
3) In the test-file instantiation, I changed the arguments passed from (activityData, user) to (activityData, user.id, user).

**Where should the reviewer start?**
- Start with the live server and check the display for anything anomalous
- Inspect the test suite for the Utility class
- Run npm test to screen for any issues
- Inspect the Activity class's new property (this.userData)

**What are the relevant tickets?**
- resolve issue #36 
- resolve issue #41 
